### PR TITLE
fixed newline bug reported by Olaf

### DIFF
--- a/klasa.py
+++ b/klasa.py
@@ -15,9 +15,10 @@ import bz2
 import sys
 from pywikibot.data.api import Request
 from os import environ
-import mwparserfromhell
+#import mwparserfromhell
 from copy import deepcopy
 
+'''experimental: think about using mwparserfromhell
 def parseTitle(title):
     site = pywikibot.Site()
     page = pywikibot.Page(site, title)
@@ -26,7 +27,7 @@ def parseTitle(title):
 
 def parseText(text):
     return mwparserfromhell.parse(text)
-
+'''
 locale.setlocale(locale.LC_COLLATE,"pl_PL.UTF-8")
 #possible types:
 #0 - redirect
@@ -184,7 +185,7 @@ def generateRegexp(order):
         if i == len(order) - 1:
             order[i].regex = re.compile(ur'%s(.*)' % (order[i].template), re.DOTALL)
         else:
-            order[i].regex = re.compile(ur'%s(.*?)%s' % (order[i].template, order[i+1].template), re.DOTALL)
+            order[i].regex = re.compile(ur'%s(.*?)\n%s' % (order[i].template, order[i+1].template), re.DOTALL)
 
 #possible types:
 #1 - proper section, all normal languages


### PR DESCRIPTION
Olaf found the bug here: https://pl.wiktionary.org/w/index.php?title=Burundi&diff=4729258&oldid=4710675#Burundi_.28j.C4.99zyk_du.C5.84ski.29
Bot was adding a gratuitous newline. Fixed the regex and it should be fine now.
