### PR TITLE
preventing #8

### DIFF
--- a/rzeczownik_rodzaj_niepotrzebny.py
+++ b/rzeczownik_rodzaj_niepotrzebny.py
@@ -18,7 +18,7 @@ def rzeczownikRodzajNiepotrzebny(data):
 	
 	re_excluded = re.compile(ur'Lista języków, w których rzeczowniki nie mają rodzaju. Jeśli wiesz o takim, dopisz go do poniższej listy, a bot nie będzie uwzględniał go w tworzeniu listy:\n\n(.*)', re.DOTALL)
 	s_excluded = re.search(re_excluded, noGenderPage.get())
-	noGenderList = s_excluded.group(1).split(u'\n')
+	noGenderList = set(s_excluded.group(1).split(u'\n'))
 	for a in noGenderList:
 		a = a.strip()
 


### PR DESCRIPTION
the bug was not in the code but someone put japanese twice on the
source
list (https://pl.wiktionary.org/wiki/Wikipedysta:AlkamidBot/listy/rodzaj/wykluczone),
but converting the list to a set will be immune to such mistakes.
fixes #8 
