### PR TITLE
Fix HTML in 'Kategoria:<lang> (indeks)' pages

### DIFF
--- a/addLang.py
+++ b/addLang.py
@@ -71,7 +71,7 @@ def addLang(shortName, code, etym, shortOnly = False, jakie = None, zjezyka = No
     page2 = pywikibot.Page(site, 'Kategoria:%s (indeks)' % shortName)
     try: page2.get()
     except pywikibot.NoPage:
-        page2.text = '<div align=center>\'\'\'[[:Kategoria:%s|%s]]\'\'\'<p>{{indeks|%s}}</div>\n{{dodajhasło}}\n[[Kategoria:Indeks słów wg języków]]\n[[Kategoria:%s| ]]' % (longNameCapital, longNameCapital, shortName, longNameCapital)
+        page2.text = '<div style="text-align: center;">\'\'\'[[:Kategoria:%s|%s]]\'\'\'</div>\n{{indeks|%s}}\n{{dodajhasło}}\n\n[[Kategoria:Indeks słów wg języków]]\n[[Kategoria:%s| ]]' % (longNameCapital, longNameCapital, shortName, longNameCapital)
         page2.save(summary="Dodanie języka %s" % zjezyka)
         #print textPage2
     else:


### PR DESCRIPTION
Several pages from the Category namespace were showing up in Special:LintErrors, note the lonely &lt;p&gt; tag. Also, the 'align' attribute is not supported in HTML5. All on-wiki occurrences have been processed wit a bot using this scheme as reference.

* https://pl.wiktionary.org/wiki/Specjalna:LintErrors/missing-end-tag
* https://pl.wiktionary.org/w/index.php?diff=6191082&oldid=4270816
* https://www.w3schools.com/tags/att_div_align.asp